### PR TITLE
feat: add readerPrincipalIds parameter for read-only access

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Azure Resource Manager (ARM) template that creates an Azure Storage account to s
 | `allowSharedAccessKey` | Allow authenticating to the storage account using a shared access key? | `bool` | `false` |
 | `ipRules` | An array of IP addresses or ranges that should be granted access to the storage account. If empty, all IP addresses and ranges will be granted access to the storage account. | `array` | `[]` |
 | `principalIds` | An array of object IDs for user, group or service principals that should be allowed to authenticate to the storage account using Microsoft Entra. | `array` | `[]` |
+| `readerPrincipalIds` | An array of object IDs for user, group or service principals that should be granted read-only access to the storage account using Microsoft Entra. | `array` | `[]` |
 
 > [!TIP]
 > Rather than passing parameters as inline values, create a [parameter file](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/parameter-files).

--- a/main.bicep
+++ b/main.bicep
@@ -18,6 +18,9 @@ param ipRules array = []
 @description('An array of object IDs of user, group or service principals that should have access to the Terraform backend.')
 param principalIds array = []
 
+@description('An array of object IDs of user, group or service principals that should have read-only access to the Terraform backend.')
+param readerPrincipalIds array = []
+
 param storageDeploymentName string = 'storage-${utcNow()}'
 
 var location = deployment().location
@@ -36,5 +39,6 @@ module storage 'modules/storage.bicep' = {
     allowSharedKeyAccess: allowSharedKeyAccess
     ipRules: ipRules
     principalIds: principalIds
+    readerPrincipalIds: readerPrincipalIds
   }
 }

--- a/modules/storage.bicep
+++ b/modules/storage.bicep
@@ -13,6 +13,9 @@ param ipRules array = []
 @description('An array of object IDs of user, group or service principals that should have access to the Terraform backend.')
 param principalIds array = []
 
+@description('An array of object IDs of user, group or service principals that should have read-only access to the Terraform backend.')
+param readerPrincipalIds array = []
+
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: storageAccountName
   location: resourceGroup().location
@@ -97,6 +100,11 @@ resource roleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-01-prev
   scope: subscription()
 }
 
+resource readerRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-01-preview' existing = {
+  name: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1' // Storage Blob Data Reader
+  scope: subscription()
+}
+
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for principalId in principalIds: {
     name: guid(storageAccount::blobService::container.id, principalId, roleDefinition.id)
@@ -108,10 +116,21 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   }
 ]
 
+resource readerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for principalId in readerPrincipalIds: {
+    name: guid(storageAccount::blobService::container.id, principalId, readerRoleDefinition.id)
+    scope: storageAccount::blobService::container
+    properties: {
+      principalId: principalId
+      roleDefinitionId: readerRoleDefinition.id
+    }
+  }
+]
+
 resource lock 'Microsoft.Authorization/locks@2020-05-01' = {
   name: 'Terraform'
   scope: storageAccount
-  dependsOn: [storageAccount::blobService, storageAccount::managementPolicy, roleAssignment] // Lock must be created last
+  dependsOn: [storageAccount::blobService, storageAccount::managementPolicy, roleAssignment, readerRoleAssignment] // Lock must be created last
   properties: {
     level: 'ReadOnly'
     notes: 'Prevent changes to Terraform backend configuration'


### PR DESCRIPTION
## Motivation

I want to separate the `plan` and `apply` stages to different service principals when using the Terraform CLI in a GitHub Actions workflow. The `plan` stage only needs read access to the state, while `apply` needs read/write. Granting only `Storage Blob Data Reader` to the plan identity follows least-privilege.

## Summary

Adds a new optional `readerPrincipalIds` parameter that grants the **Storage Blob Data Reader** role on the tfstate container to the listed user, group, or service principals.

Backwards compatible — parameter is optional and defaults to an empty array.